### PR TITLE
Eigen cast fix MacOS

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -21,4 +21,4 @@ sudo make install
 cd ../pylqr_planner
 cmake ../../pylqr_planner -DCMAKE_BUILD_TYPE=Release
 make -j $num_thread
-sudo make install
+make install

--- a/ilqr_planner/ilqr_planner/include/ilqr_planner/utils/utils.h
+++ b/ilqr_planner/ilqr_planner/include/ilqr_planner/utils/utils.h
@@ -136,7 +136,7 @@ inline std::array<double, s> eigenVectorToStdArray(const Eigen::VectorXd& vec) {
  */
 template <size_t s>
 std::array<double, s> eigenMatrixToStdArray(const Eigen::MatrixXd& mat) {
-    Eigen::VectorXd vec(Eigen::Map<Eigen::VectorXd>(mat.data(), mat.cols() * mat.rows()));
+    Eigen::VectorXd vec(Eigen::Map<Eigen::VectorXd>(const_cast<double*>(mat.data()), mat.cols() * mat.rows()));
     std::array<double, s> arr{};
     Eigen::VectorXd::Map(&arr[0], s) = vec;
     return arr;


### PR DESCRIPTION
On MacOS I got this error for "utils.h"
```
error: no matching constructor for initialization of 'Eigen::Map<Eigen::VectorXd>' (aka 'Map<Matrix<double, Dynamic, 1>>')
    Eigen::VectorXd vec(Eigen::Map<Eigen::VectorXd>(mat.data(), mat.cols() * mat.rows()));
```

Fixed by adding a cast to double: 
```C
Eigen::VectorXd vec(Eigen::Map<Eigen::VectorXd>(const_cast<double*>(mat.data()), mat.cols() * mat.rows()));
```